### PR TITLE
UBO-309 add rate limiting uri resolver

### DIFF
--- a/src/main/resources/config/ubo-due/mycore.properties
+++ b/src/main/resources/config/ubo-due/mycore.properties
@@ -182,3 +182,10 @@ MCR.MODS.EnrichmentResolver.DataSources.import-list=(Scopus CrossRef PubMed IEEE
 MCR.MODS.EnrichmentResolver.DataSource.Primo.IdentifierTypes=doi
 MCR.MODS.EnrichmentResolver.DataSource.Primo.doi.URI=xslStyle\:import/simplify-json-xml,import/primo2mods\:xslTransform\:json2xml\:https\://primo.uni-due.de/primaws/rest/pub/pnxs?inst\=49HBZ_UDE&isCDSearch\=true&pcAvailability\=false&scope\=MyInst_and_CI_custom&tab\=Everything&vid\=49HBZ_UDE:UDE&q\=doi,exact,{1}
 
+######################################################################
+#                                                                    #
+#                           Rate Limits                              #
+#                                                                    #
+######################################################################
+
+MCR.RateLimitResolver.IEEEDay.Limits=400/d

--- a/src/main/resources/config/ubo-due/mycore.properties
+++ b/src/main/resources/config/ubo-due/mycore.properties
@@ -145,6 +145,22 @@ MCR.MODS.EnrichmentResolver.DataSources.scopus-import=Unpaywall (LOBID Alma) ZDB
 
 ######################################################################
 #                                                                    #
+#                            Scopus Importer                         #
+#                                                                    #
+######################################################################
+
+MCR.Cronjob.Jobs.ScopusImporter=org.mycore.mcr.cronjob.MCRCommandCronJob
+MCR.Cronjob.Jobs.ScopusImporter.Enabled=true
+MCR.Cronjob.Jobs.ScopusImporter.Contexts=WEBAPP
+MCR.Cronjob.Jobs.ScopusImporter.CronType=UNIX
+MCR.Cronjob.Jobs.ScopusImporter.Cron=15 7 * * *
+MCR.Cronjob.Jobs.ScopusImporter.Command=ubo update from scopus for affiliation IDs %MCR.Cronjob.Jobs.ScopusImporter.AffliliationIDs% last %MCR.Cronjob.Jobs.ScopusImporter.MaxDays% days max %MCR.Cronjob.Jobs.ScopusImporter.MaxEntries%
+MCR.Cronjob.Jobs.ScopusImporter.AffliliationIDs=60014264,60007896,60072311,60017868
+MCR.Cronjob.Jobs.ScopusImporter.MaxDays=2
+MCR.Cronjob.Jobs.ScopusImporter.MaxEntries=100
+
+######################################################################
+#                                                                    #
 #                       Journals online & print                      #
 #                                                                    #
 ######################################################################


### PR DESCRIPTION
Configure ScopusImporter to run as a MCRCommandCronJob, custom rate limit for datasource IEEE