### PR TITLE
Filter for lowering session timeout in Solr Servlet

### DIFF
--- a/src/main/java/org/mycore/ubo/session/SessionTimeoutFilter.java
+++ b/src/main/java/org/mycore/ubo/session/SessionTimeoutFilter.java
@@ -1,0 +1,92 @@
+package org.mycore.ubo.session;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.access.mcrimpl.MCRIPAddress;
+import org.mycore.common.config.MCRConfiguration2;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Decreases session time for all requests from all IP-addresses not registered in the allowlist MCR.Filter.SessionTimeout.Allowlist
+ */
+public class SessionTimeoutFilter implements Filter {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static List<MCRIPAddress> allowlist;
+
+    /** timeout length in seconds */
+    private static final int TIMEOUT_LENGTH = MCRConfiguration2
+        .getOrThrow("MCR.Filter.SessionTimeout.TimeoutLength", Integer::parseInt);
+
+    @Override
+    public void init(final FilterConfig arg0) {
+        final String allowlistAll = MCRConfiguration2.getString("MCR.Filter.SessionTimeout.Allowlist").orElse("");
+            allowlist = Arrays.stream(allowlistAll.split(","))
+                .map(String::trim)
+                .map(this::createAddress)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void doFilter(ServletRequest sreq, ServletResponse sres, FilterChain chain)
+        throws IOException, ServletException {
+        final HttpServletRequest request = (HttpServletRequest) sreq;
+
+        final boolean newSession = request.getSession(false) == null;
+        try {
+            chain.doFilter(sreq, sres);
+        } finally {
+            final HttpSession session = request.getSession(false);
+            if (session != null && newSession) {
+                String clientIp = request.getRemoteAddr();
+                try {
+                    MCRIPAddress mcrIpAddressClient = new MCRIPAddress(clientIp);
+                    if (!isAllowedIp(mcrIpAddressClient)) {
+                        session.setMaxInactiveInterval(TIMEOUT_LENGTH);
+                        LOGGER.debug(String.format("Session with client-IP" + clientIp + " expires in " + TIMEOUT_LENGTH +" seconds"));
+                    }
+                } catch (UnknownHostException e) {
+                    LOGGER.warn("Invalid remote address: {}", clientIp);
+                }
+
+            }
+        }
+    }
+
+    private boolean isAllowedIp(MCRIPAddress ip) {
+        for (MCRIPAddress allowlistIp : allowlist) {
+            if (Arrays.equals(allowlistIp.getAddress(), ip.getAddress())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private MCRIPAddress createAddress(String ip) {
+        if (ip == null || ip.isEmpty()) {
+            return null;
+        }
+        try {
+            return new MCRIPAddress(ip);
+        } catch (UnknownHostException e) {
+            LOGGER.error("Invalid remote address: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/resources/META-INF/web-fragment.xml
+++ b/src/main/resources/META-INF/web-fragment.xml
@@ -14,4 +14,17 @@
     <url-pattern>/servlets/LSFSearchServlet</url-pattern>
   </servlet-mapping>
 
+  <filter>
+    <filter-name>SessionTimeoutFilter</filter-name>
+    <filter-class>org.mycore.ubo.session.SessionTimeoutFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>SessionTimeoutFilter</filter-name>
+    <url-pattern>/servlets/solr/*</url-pattern>
+    <dispatcher>REQUEST</dispatcher>
+  </filter-mapping>
+
+
+
 </web-fragment>

--- a/src/main/resources/config/ubo-due/mycore.properties
+++ b/src/main/resources/config/ubo-due/mycore.properties
@@ -197,3 +197,9 @@ UBO.PredefinedExport.Schierning.SOLRURI=%UBO.PredefinedExport.DefaultSOLRURISele
 UBO.PredefinedExport.f965e377-ce3f-481e-967a-6004f3d0b3e6.URI=xslTransform:response-csl-json:%UBO.PredefinedExport.Schierning.SOLRURI%
 UBO.PredefinedExport.52df911b-b6f9-4a7e-be51-65b6df12b2bf.URI=xslTransform:response-csl-html-ieee:%UBO.PredefinedExport.Schierning.SOLRURI%
 UBO.PredefinedExport.a925f889-1d43-4ad8-99ea-2e3bcb0e5a4e.URI=xslTransform:bibtex:%UBO.PredefinedExport.Schierning.SOLRURI%
+
+
+# All IP-addresses that are excluded from the SessionTimeout
+MCR.Filter.SessionTimeout.Allowlist=
+# Timeout length in seconds
+MCR.Filter.SessionTimeout.TimeoutLength=180


### PR DESCRIPTION
Lokal getestet und funktioniert so weit gut. Die ausgenommenen IP-Adressen und die Timeout Zeit sind konfigurierbar. Request-Pfade sind in web-fragment.xml hardcodiert.

Stärkster Nebeneffekt einer neuer Session ist das Logout des angemeldeten Users. D. h. dass ein externer User, der seine Session als Gast mit einem SOLR-Request beginnt und sich dann einloggt, nach der konfigurierten Zeit ausgeloggt wird. Das Heruntersetzen des Session-Timeouts wird nicht mehr rückgängig gemacht.