### PR TITLE
Update Maven Repository config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,12 @@
 
   <repositories>
     <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </snapshots>
-      <id>ossrhs01</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
       <releases>
@@ -62,32 +60,11 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central-portal-snapshots</id>
+      <name>Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </repository>
   </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>ossrhs01</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Konfig von ubo übernommen. Extra pluginRepository wahrscheinlich nicht mehr benötigt.
Lokal getestet, indem ich gesamten .m2 Ordner gelöscht und ubo-due erfolgreich gebaut habe.