### PR TITLE
UBO-421 always send emails for scopus import, even if no new publications

### DIFF
--- a/src/main/resources/config/ubo-due/mycore.properties
+++ b/src/main/resources/config/ubo-due/mycore.properties
@@ -156,6 +156,9 @@ MCR.Cronjob.Jobs.ScopusImporter.AffliliationIDs=60014264,60007896,60072311,60017
 MCR.Cronjob.Jobs.ScopusImporter.MaxDays=2
 MCR.Cronjob.Jobs.ScopusImporter.MaxEntries=100
 
+# always send the import email, even if no new imports happened
+UBO.Scopus.Importer.Mail.AlwaysSend=true
+
 ######################################################################
 #                                                                    #
 #                             CSV Import                             #


### PR DESCRIPTION
Configuration change only. Code was changed in UBO: https://github.com/MyCoRe-Org/ubo/pull/477/files
Flag functionality is already installed, and must now be activated.
[Ticket](https://mycore.atlassian.net/browse/UBO-421)