### PR TITLE
Overwrite ORCID EventHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.mycore.ubo</groupId>
       <artifactId>ubo-common</artifactId>
-      <version>prod-SNAPSHOT</version>
+      <version>2024.06.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/src/main/java/org/mycore/orcid2/v3/work/UBOORCIDWorkEventHandlerImpl.java
+++ b/src/main/java/org/mycore/orcid2/v3/work/UBOORCIDWorkEventHandlerImpl.java
@@ -1,0 +1,70 @@
+package org.mycore.orcid2.v3.work;
+
+import java.util.List;
+import java.util.Set;
+
+import org.mycore.common.content.MCRJDOMContent;
+import org.mycore.orcid2.client.MCRORCIDCredential;
+import org.mycore.orcid2.metadata.MCRORCIDPutCodeInfo;
+import org.mycore.orcid2.util.MCRIdentifier;
+import org.mycore.orcid2.v3.transformer.MCRORCIDWorkTransformerHelper;
+import org.mycore.orcid2.work.MCRORCIDWorkEventHandler;
+import org.orcid.jaxb.model.v3.release.record.Work;
+
+/**
+ * Overrides {@link MCRORCIDWorkEventHandlerImpl} to allow for repair.
+ */
+public class UBOORCIDWorkEventHandlerImpl extends MCRORCIDWorkEventHandler<Work> {
+
+    @Override
+    protected void removeWork(MCRORCIDPutCodeInfo workInfo, String orcid, MCRORCIDCredential credential) {
+        MCRORCIDWorkService.doDeleteWork(workInfo, orcid, credential);
+    }
+
+    @Override
+    protected void createWork(Work work, MCRORCIDPutCodeInfo workInfo, String orcid, MCRORCIDCredential credential) {
+        MCRORCIDWorkService.doCreateWork(work, workInfo, orcid, credential);
+    }
+
+    @Override
+    protected void updateWork(long putCode, Work work, String orcid, MCRORCIDCredential credential) {
+        MCRORCIDWorkService.doUpdateWork(putCode, work, orcid, credential);
+    }
+
+    @Override
+    protected void updateWorkInfo(Set<MCRIdentifier> identifiers, MCRORCIDPutCodeInfo workInfo, String orcid,
+        MCRORCIDCredential credential) {
+        MCRORCIDWorkService.doUpdateWorkInfo(identifiers, workInfo, orcid, credential);
+    }
+
+    @Override
+    protected void updateWorkInfo(Set<MCRIdentifier> identifiers, MCRORCIDPutCodeInfo workInfo, String orcid) {
+        MCRORCIDWorkService.doUpdateWorkInfo(identifiers, workInfo, orcid);
+    }
+
+    @Override
+    protected Set<MCRIdentifier> listTrustedIdentifiers(Work work) {
+        return MCRORCIDWorkUtils.listTrustedIdentifiers(work);
+    }
+
+    @Override
+    protected Set<String> findMatchingORCIDs(Set<MCRIdentifier> identifiers) {
+        return MCRORCIDWorkService.findMatchingORCIDs(identifiers);
+    }
+
+    @Override
+    protected Work transformObject(MCRJDOMContent object) {
+        return MCRORCIDWorkTransformerHelper.transformContent(object);
+    }
+
+    @Override
+    protected List<String> listRelatedOrcidIdentifiers(Work work) {
+        if (work.getWorkContributors() != null && work.getWorkContributors().getContributor() != null) {
+            return work.getWorkContributors().getContributor().stream().filter(c -> c.getContributorOrcid() != null)
+                .filter(c -> c.getContributorAttributes() != null)
+                .filter(c -> c.getContributorAttributes().getContributorRole() != null)
+                .map(c -> c.getContributorOrcid().getPath()).toList();
+        }
+        return List.of();
+    }
+}

--- a/src/main/java/org/mycore/orcid2/v3/work/UBOORCIDWorkEventHandlerImpl.java
+++ b/src/main/java/org/mycore/orcid2/v3/work/UBOORCIDWorkEventHandlerImpl.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.mycore.common.content.MCRJDOMContent;
+import org.mycore.common.events.MCREvent;
+import org.mycore.datamodel.metadata.MCRObject;
 import org.mycore.orcid2.client.MCRORCIDCredential;
 import org.mycore.orcid2.metadata.MCRORCIDPutCodeInfo;
 import org.mycore.orcid2.util.MCRIdentifier;
@@ -15,6 +17,11 @@ import org.orcid.jaxb.model.v3.release.record.Work;
  * Overrides {@link MCRORCIDWorkEventHandlerImpl} to allow for repair.
  */
 public class UBOORCIDWorkEventHandlerImpl extends MCRORCIDWorkEventHandler<Work> {
+
+    @Override
+    protected void handleObjectRepaired(MCREvent evt, MCRObject object)  {
+        handleObjectUpdated(evt, object);
+    }
 
     @Override
     protected void removeWork(MCRORCIDPutCodeInfo workInfo, String orcid, MCRORCIDCredential credential) {

--- a/src/main/resources/config/ubo-due/mycore.properties
+++ b/src/main/resources/config/ubo-due/mycore.properties
@@ -89,8 +89,8 @@ MCR.ORCID2.Work.PublishStates=confirmed
 MCR.ORCID2.User.TrustedNameIdentifierTypes=orcid,gnd,lsf
 
 # Activate event handler for syncing works to ORCID when they are updated in MyCoRe.
-# Activate in local mycore.properties. Requires ORCID credentials and API config.
-# MCR.EventHandler.MCRObject.018A.Class=org.mycore.orcid2.v3.work.MCRORCIDWorkEventHandlerImpl
+# Activate in local mycore.properties. Requires ORCID credentials and API config. Local Override.
+# MCR.EventHandler.MCRObject.018A.Class=org.mycore.orcid2.v3.work.UBOORCIDWorkEventHandlerImpl
 
 # New publication in UBO will be written to ORCID profile. 
 MCR.ORCID2.WorkEventHandler.CreateFirstWork=true


### PR DESCRIPTION
Overrides an EventHandler to make repair behavior possible. Needed to mass-populate ORCID profiles via command line.
Lets talk about this one in person.